### PR TITLE
Added dependency on RainLab.Blog plugin

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -12,6 +12,7 @@ use AnandPatel\SeoExtension\classes\Helper;
  */
 class Plugin extends PluginBase
 {
+  public $require = ['RainLab.Blog'];
 
     /**
      * Returns information about this plugin.

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -7,3 +7,5 @@
       - Backend Settings added to configure meta tags & Open Graph tags added
 1.0.4:
       - code clean up and change path naming in settings model
+1.0.5:
+      - Added dependency on RainLab.Blog plugin 


### PR DESCRIPTION
I added the dependency because the plugin modifies the blog plugins tables. Issues arise sometimes when you clear all tables and want to rebuild from start again. Without the dependency, Octobercms sometimes to run your plugin before the blog plugin and hence causes error because the blog plugin has not created the base table yet.