### PR TITLE
remove context from registerSettings -> settings

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -45,7 +45,6 @@ class Plugin extends PluginBase
                 'label'       => 'anandpatel.seoextension::lang.settings.label',
                 'description' => 'anandpatel.seoextension::lang.settings.description',
                 'icon'        => 'icon-search',
-                'context'     => 'mysettings',
                 'category'    =>  SettingsManager::CATEGORY_MYSETTINGS,
                 'class'       => 'AnandPatel\SeoExtension\Models\Settings',
                 'order'       => 100


### PR DESCRIPTION
In the October CMS version (build 318) I tested on "Configure SEO Extensions" is not visible in the "Settings" menu of the backend.

Hope you can apply my pull request which contains a fix for this.

Thanks.