### PR TITLE
Fix post canonical URL

### DIFF
--- a/classes/Helper.php
+++ b/classes/Helper.php
@@ -80,7 +80,7 @@ class Helper {
                 $ogTags  .= '<meta property="og:description" content="'.$post->seo_description.'" />'."\n" ;
 
             $ogTitle = empty($post->meta_title) ? $post->title : $post->meta_title;
-            $ogUrl = empty($post->canonical_url) ? Request::url() : $this->page->canonical_url ;
+            $ogUrl = empty($post->canonical_url) ? Request::url() : $post->canonical_url ;
 
             $ogTags .= '<meta property="og:title" content="'. $ogTitle .'" />'."\n" ;
 


### PR DESCRIPTION
This change fixes a bug in the canonical_url lookup for SeoBlogPosts, where the user was forced to either define a canonical url on the page, or else the page would throw an error.