### PR TITLE
Added handling for null $post in helper

### DIFF
--- a/classes/Helper.php
+++ b/classes/Helper.php
@@ -2,7 +2,9 @@
 
 use AnandPatel\SeoExtension\Models\Settings;
 use Request;
-class Helper {
+
+class Helper
+{
 
     public $settings;
 
@@ -17,22 +19,16 @@ class Helper {
         $settings = $this->settings;
         $new_title = "";
 
-        if($settings->enable_title)
-        {
+        if ($settings->enable_title) {
             $position = $settings->title_position;
             $site_title = $settings->title;
 
-            if($position == 'prefix')
-            {
+            if ($position == 'prefix') {
                 $new_title = $site_title . " " . $title;
-            }
-            else
-            {
+            } else {
                 $new_title = $title . " " . $site_title;
             }
-        }
-        else
-        {
+        } else {
             $new_title = $title;
         }
         return $new_title;
@@ -42,9 +38,8 @@ class Helper {
     {
         $settings = $this->settings;
 
-        if($settings->enable_canonical_url)
-        {
-            return '<link rel="canonical" href="'. Request::url().'"/>';
+        if ($settings->enable_canonical_url) {
+            return '<link rel="canonical" href="' . Request::url() . '"/>';
         }
 
         return "";
@@ -54,8 +49,7 @@ class Helper {
     {
         $settings = $this->settings;
 
-        if($settings->other_tags)
-        {
+        if ($settings->other_tags) {
             return $settings->other_tags;
         }
 
@@ -65,26 +59,28 @@ class Helper {
 
     public function generateOgMetaTags($post)
     {
+        if ($post === null) {
+            return '';
+        }
         $settings = $this->settings;
 
-        if($settings->enable_og_tags)
-        {
+        if ($settings->enable_og_tags) {
             $ogTags = "";
-            if($settings->og_fb_appid)
-                $ogTags  .= '<meta property="fb:app_id" content="'.$settings->og_fb_appid.'" />' ."\n" ;
+            if ($settings->og_fb_appid)
+                $ogTags .= '<meta property="fb:app_id" content="' . $settings->og_fb_appid . '" />' . "\n";
 
-            if($settings->og_sitename)
-                $ogTags  .= '<meta property="og:site_name" content="'.$settings->og_sitename .'" />'."\n" ;
+            if ($settings->og_sitename)
+                $ogTags .= '<meta property="og:site_name" content="' . $settings->og_sitename . '" />' . "\n";
 
-            if($post->seo_description)
-                $ogTags  .= '<meta property="og:description" content="'.$post->seo_description.'" />'."\n" ;
+            if ($post->seo_description)
+                $ogTags .= '<meta property="og:description" content="' . $post->seo_description . '" />' . "\n";
 
             $ogTitle = empty($post->meta_title) ? $post->title : $post->meta_title;
-            $ogUrl = empty($post->canonical_url) ? Request::url() : $this->page->canonical_url ;
+            $ogUrl = empty($post->canonical_url) ? Request::url() : $this->page->canonical_url;
 
-            $ogTags .= '<meta property="og:title" content="'. $ogTitle .'" />'."\n" ;
+            $ogTags .= '<meta property="og:title" content="' . $ogTitle . '" />' . "\n";
 
-            $ogTags .= '<meta property="og:url" content="'. $ogUrl .'" />';
+            $ogTags .= '<meta property="og:url" content="' . $ogUrl . '" />';
 
             return $ogTags;
         }


### PR DESCRIPTION
Switching my production rainlab.blog to https://github.com/rainlab/blog-plugin/pull/316 introduced an Exception where $post is null when front-end viewing unpublished posts. 

This PR adds handling to classes/Helper.php::generateOgMetaTags() to workaround the null $post situation. 