### PR TITLE
Added plugin dependencies to the $required property

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -12,6 +12,12 @@ use System\Classes\SettingsManager;
  */
 class Plugin extends PluginBase
 {
+    
+    /**
+     * @var array Plugin dependencies
+     */
+    public $require = ['Rainlab.Blog'];
+    
 
     /**
      * Returns information about this plugin.


### PR DESCRIPTION
I was creating a new instance of my application and when I was going through the database migrations, since those of the seoextension plugin run first, mysql throws an error because there are no Rainlab.blog tables migrated yet.

```
[Illuminate\Database\QueryException]
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'website.rainlab_blog_posts' doesn't exist (SQL: alter table `rainlab_blog_posts` ad   
  d `seo_title` varchar(191) null, add `seo_description` varchar(191) null, add `seo_keywords` varchar(191) null, add `canonical_url` varchar(191)   
   null, add `redirect_url` varchar(191) null, add `robot_index` varchar(191) null, add `robot_follow` varchar(191) null)
```

To solve the issue, I just provided the required property inside Plugin class.

To test it, I had to remove the plugin and installing it again to "purge" the registration.

It's working fine now.